### PR TITLE
Added deploy.env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,6 @@ node_modules
 
 
 .env
+deploy.env
 event.json
 .DS_Store


### PR DESCRIPTION
Hi @motdotla, 

node-lambda setup creates the files: .env, event.json, deploy.env

I see the first two are in .gitignore, but deploy.env isn't.

Since it may contain secret values, I added it to .gitignore also.
